### PR TITLE
[Feat/#20] TanStack Query를 적용하여 CalendarList API 결과 렌더링

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
     'plugin:import/typescript',
     'plugin:react-hooks/recommended',
     'plugin:prettier/recommended',
+    'plugin:@tanstack/eslint-plugin-query/recommended'
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "date-fns": "^3.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-router-dom": "^6.21.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",
+    "@tanstack/react-query": "^5.25.0",
     "axios": "^1.6.7",
     "date-fns": "^3.3.1",
     "react": "^18.2.0",
@@ -18,6 +19,7 @@
     "react-router-dom": "^6.21.1"
   },
   "devDependencies": {
+    "@tanstack/eslint-plugin-query": "^5.20.1",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@types/react-router-dom": "^5.3.3",

--- a/src/apis/googleCalendar.ts
+++ b/src/apis/googleCalendar.ts
@@ -1,0 +1,8 @@
+import { instance } from '@/apis/axiosInstance';
+
+const getCalendarList = async (): Promise<GoogleAppsScript.Calendar.Schema.CalendarList> => {
+  const { data } = await instance.get('/users/me/calendarList');
+  return data;
+};
+
+export { getCalendarList };

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,14 +1,17 @@
+import CalendarSelector from '@/components/calendar/CalendarSelector';
 import DateGrids from '@/components/calendar/DateGrids';
 import MonthNavigation from '@/components/calendar/MonthNavigation';
+import { useAuthContext } from '@/contexts/AuthProvider';
 import useCalendar from '@/hooks/useCalendar';
 
 const Calendar = () => {
   const { currentDate, prevMonth, nextMonth, prevMonthDates, currMonthDates, nextMonthDates } =
     useCalendar();
+  const { user } = useAuthContext();
 
   return (
     <div>
-      {/* 구글 캘린더 목록 영역 */}
+      {user && <CalendarSelector />}
       <MonthNavigation date={currentDate} prevMonth={prevMonth} nextMonth={nextMonth} />
       <DateGrids
         prevMonthDates={prevMonthDates}

--- a/src/components/calendar/CalendarSelector.tsx
+++ b/src/components/calendar/CalendarSelector.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorFallback from '@/components/fallback/ErrorFallback';
+import LoadingFallback from '@/components/fallback/LoadingFallback';
+import { useSuspenseCalendarList } from '@/hooks/queries/calendar';
+
+const CalendarDropDown = () => {
+  const { data } = useSuspenseCalendarList();
+
+  // 드롭다운 구현 예정
+  return <div>{data.items?.map((data) => <div key={data.etag}>{data.summary}</div>)}</div>;
+};
+
+const CalendarSelector = () => {
+  return (
+    <div>
+      <ErrorBoundary fallback={<ErrorFallback />}>
+        <Suspense fallback={<LoadingFallback />}>
+          <CalendarDropDown />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default CalendarSelector;

--- a/src/components/fallback/ErrorFallback.tsx
+++ b/src/components/fallback/ErrorFallback.tsx
@@ -1,0 +1,5 @@
+const ErrorFallback = () => {
+  return <div>에러가 발생하였습니다.</div>;
+};
+
+export default ErrorFallback;

--- a/src/components/fallback/LoadingFallback.tsx
+++ b/src/components/fallback/LoadingFallback.tsx
@@ -1,0 +1,5 @@
+const LoadingFallback = () => {
+  return <div>데이터를 받아오는 중입니다...</div>;
+};
+
+export default LoadingFallback;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,7 @@
+const QUERY_KEYS = {
+  calendar: {
+    list: 'calendarList',
+  },
+} as const;
+
+export default QUERY_KEYS;

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, createContext, useContext, useEffect, useState } fro
 import { setAccessToken } from '@/apis/axiosInstance';
 import supabase from '@/apis/supabaseClient';
 
-const AuthContext = createContext<AuthContextProps>({
+const AuthContext = createContext<AuthContextState>({
   user: null,
   session: null,
 });
@@ -46,7 +46,7 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
-interface AuthContextProps {
+interface AuthContextState {
   user: User | null;
   session: Session | null;
 }

--- a/src/hooks/queries/calendar.ts
+++ b/src/hooks/queries/calendar.ts
@@ -1,0 +1,12 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getCalendarList } from '@/apis/googleCalendar';
+import QUERY_KEYS from '@/constants/queryKeys';
+
+export const useSuspenseCalendarList = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: [QUERY_KEYS.calendar.list],
+    queryFn: getCalendarList,
+  });
+
+  return { data };
+};

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -11,7 +11,7 @@ import {
 } from 'date-fns';
 import { useState } from 'react';
 
-const useCalendar = (): CalendarProps => {
+const useCalendar = (): CalendarResult => {
   const [currentDate, setCurrentDate] = useState(new Date());
 
   const firstDayOfMonth = () => {
@@ -63,7 +63,7 @@ const useCalendar = (): CalendarProps => {
   };
 };
 
-interface CalendarProps {
+interface CalendarResult {
   currentDate: Date;
   firstDayOfMonth: () => Date;
   lastDayOfMonth: () => Date;

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,6 +1,6 @@
 import supabase from '@/apis/supabaseClient';
 
-const useSupabaseAuth = (): AuthProps => {
+const useSupabaseAuth = (): AuthResult => {
   const logInWithGoogle = async () => {
     await supabase.auth.signInWithOAuth({
       provider: 'google',
@@ -21,7 +21,7 @@ const useSupabaseAuth = (): AuthProps => {
   return { logInWithGoogle, logOutWithGoogle };
 };
 
-interface AuthProps {
+interface AuthResult {
   logInWithGoogle: () => Promise<void>;
   logOutWithGoogle: () => Promise<void>;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
@@ -5,10 +6,14 @@ import AuthProvider from '@/contexts/AuthProvider';
 import router from '@/router';
 import '@/index.css';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <RouterProvider router={router} />
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/types/calendar_v3.d.ts
+++ b/src/types/calendar_v3.d.ts
@@ -1,0 +1,800 @@
+// https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace GoogleAppsScript {
+  namespace Calendar {
+    namespace Collection {
+      interface AclCollection {
+        // Returns an access control rule.
+        get(calendarId: string, ruleId: string): Calendar.Schema.AclRule;
+        // Returns an access control rule.
+        get(
+          calendarId: string,
+          ruleId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.AclRule;
+        // Creates an access control rule.
+        insert(resource: Schema.AclRule, calendarId: string): Calendar.Schema.AclRule;
+        // Creates an access control rule.
+        insert(
+          resource: Schema.AclRule,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.AclRule;
+        // Creates an access control rule.
+        insert(
+          resource: Schema.AclRule,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.AclRule;
+        // Returns the rules in the access control list for the calendar.
+        list(calendarId: string): Calendar.Schema.Acl;
+        // Returns the rules in the access control list for the calendar.
+        list(calendarId: string, optionalArgs: object): Calendar.Schema.Acl;
+        // Returns the rules in the access control list for the calendar.
+        list(calendarId: string, optionalArgs: object, headers: object): Calendar.Schema.Acl;
+        // Updates an access control rule. This method supports patch semantics.
+        patch(
+          resource: Schema.AclRule,
+          calendarId: string,
+          ruleId: string,
+        ): Calendar.Schema.AclRule;
+        // Updates an access control rule. This method supports patch semantics.
+        patch(
+          resource: Schema.AclRule,
+          calendarId: string,
+          ruleId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.AclRule;
+        // Updates an access control rule. This method supports patch semantics.
+        patch(
+          resource: Schema.AclRule,
+          calendarId: string,
+          ruleId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.AclRule;
+        // Deletes an access control rule.
+        remove(calendarId: string, ruleId: string): void;
+        // Deletes an access control rule.
+        remove(calendarId: string, ruleId: string, optionalArgs: object, headers: object): void;
+        // Updates an access control rule.
+        update(
+          resource: Schema.AclRule,
+          calendarId: string,
+          ruleId: string,
+        ): Calendar.Schema.AclRule;
+        // Updates an access control rule.
+        update(
+          resource: Schema.AclRule,
+          calendarId: string,
+          ruleId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.AclRule;
+        // Updates an access control rule.
+        update(
+          resource: Schema.AclRule,
+          calendarId: string,
+          ruleId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.AclRule;
+        // Watch for changes to ACL resources.
+        watch(resource: Schema.Channel, calendarId: string): Calendar.Schema.Channel;
+        // Watch for changes to ACL resources.
+        watch(
+          resource: Schema.Channel,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Channel;
+        // Watch for changes to ACL resources.
+        watch(
+          resource: Schema.Channel,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Channel;
+      }
+      interface CalendarListCollection {
+        // Returns a calendar from the user's calendar list.
+        get(calendarId: string): Calendar.Schema.CalendarListEntry;
+        // Returns a calendar from the user's calendar list.
+        get(
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Inserts an existing calendar into the user's calendar list.
+        insert(resource: Schema.CalendarListEntry): Calendar.Schema.CalendarListEntry;
+        // Inserts an existing calendar into the user's calendar list.
+        insert(
+          resource: Schema.CalendarListEntry,
+          optionalArgs: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Inserts an existing calendar into the user's calendar list.
+        insert(
+          resource: Schema.CalendarListEntry,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Returns the calendars on the user's calendar list.
+        list(): Calendar.Schema.CalendarList;
+        // Returns the calendars on the user's calendar list.
+        list(optionalArgs: object): Calendar.Schema.CalendarList;
+        // Returns the calendars on the user's calendar list.
+        list(optionalArgs: object, headers: object): Calendar.Schema.CalendarList;
+        // Updates an existing calendar on the user's calendar list. This method supports patch semantics.
+        patch(
+          resource: Schema.CalendarListEntry,
+          calendarId: string,
+        ): Calendar.Schema.CalendarListEntry;
+        // Updates an existing calendar on the user's calendar list. This method supports patch semantics.
+        patch(
+          resource: Schema.CalendarListEntry,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Updates an existing calendar on the user's calendar list. This method supports patch semantics.
+        patch(
+          resource: Schema.CalendarListEntry,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Removes a calendar from the user's calendar list.
+        remove(calendarId: string): void;
+        // Removes a calendar from the user's calendar list.
+        remove(calendarId: string, optionalArgs: object, headers: object): void;
+        // Updates an existing calendar on the user's calendar list.
+        update(
+          resource: Schema.CalendarListEntry,
+          calendarId: string,
+        ): Calendar.Schema.CalendarListEntry;
+        // Updates an existing calendar on the user's calendar list.
+        update(
+          resource: Schema.CalendarListEntry,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Updates an existing calendar on the user's calendar list.
+        update(
+          resource: Schema.CalendarListEntry,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.CalendarListEntry;
+        // Watch for changes to CalendarList resources.
+        watch(resource: Schema.Channel): Calendar.Schema.Channel;
+        // Watch for changes to CalendarList resources.
+        watch(resource: Schema.Channel, optionalArgs: object): Calendar.Schema.Channel;
+        // Watch for changes to CalendarList resources.
+        watch(
+          resource: Schema.Channel,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Channel;
+      }
+      interface CalendarsCollection {
+        // Clears a primary calendar. This operation deletes all events associated with the primary calendar of an account.
+        clear(calendarId: string): void;
+        // Clears a primary calendar. This operation deletes all events associated with the primary calendar of an account.
+        clear(calendarId: string, optionalArgs: object, headers: object): void;
+        // Returns metadata for a calendar.
+        get(calendarId: string): Calendar.Schema.Calendar;
+        // Returns metadata for a calendar.
+        get(calendarId: string, optionalArgs: object, headers: object): Calendar.Schema.Calendar;
+        // Creates a secondary calendar.
+        insert(resource: Schema.Calendar): Calendar.Schema.Calendar;
+        // Creates a secondary calendar.
+        insert(
+          resource: Schema.Calendar,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Calendar;
+        // Updates metadata for a calendar. This method supports patch semantics.
+        patch(resource: Schema.Calendar, calendarId: string): Calendar.Schema.Calendar;
+        // Updates metadata for a calendar. This method supports patch semantics.
+        patch(
+          resource: Schema.Calendar,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Calendar;
+        // Deletes a secondary calendar. Use calendars.clear for clearing all events on primary calendars.
+        remove(calendarId: string): void;
+        // Deletes a secondary calendar. Use calendars.clear for clearing all events on primary calendars.
+        remove(calendarId: string, optionalArgs: object, headers: object): void;
+        // Updates metadata for a calendar.
+        update(resource: Schema.Calendar, calendarId: string): Calendar.Schema.Calendar;
+        // Updates metadata for a calendar.
+        update(
+          resource: Schema.Calendar,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Calendar;
+      }
+      interface ChannelsCollection {
+        // Stop watching resources through this channel
+        stop(resource: Schema.Channel): void;
+        // Stop watching resources through this channel
+        stop(resource: Schema.Channel, optionalArgs: object, headers: object): void;
+      }
+      interface ColorsCollection {
+        // Returns the color definitions for calendars and events.
+        get(): Calendar.Schema.Colors;
+        // Returns the color definitions for calendars and events.
+        get(optionalArgs: object, headers: object): Calendar.Schema.Colors;
+      }
+      interface EventsCollection {
+        // Returns an event.
+        get(calendarId: string, eventId: string): Calendar.Schema.Event;
+        // Returns an event.
+        get(calendarId: string, eventId: string, optionalArgs: object): Calendar.Schema.Event;
+        // Returns an event.
+        get(
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Imports an event. This operation is used to add a private copy of an existing event to a calendar.
+        import(resource: Schema.Event, calendarId: string): Calendar.Schema.Event;
+        // Imports an event. This operation is used to add a private copy of an existing event to a calendar.
+        import(
+          resource: Schema.Event,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Event;
+        // Imports an event. This operation is used to add a private copy of an existing event to a calendar.
+        import(
+          resource: Schema.Event,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Creates an event.
+        insert(resource: Schema.Event, calendarId: string): Calendar.Schema.Event;
+        // Creates an event.
+        insert(
+          resource: Schema.Event,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Event;
+        // Creates an event.
+        insert(
+          resource: Schema.Event,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Returns instances of the specified recurring event.
+        instances(calendarId: string, eventId: string): Calendar.Schema.Events;
+        // Returns instances of the specified recurring event.
+        instances(
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Events;
+        // Returns instances of the specified recurring event.
+        instances(
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Events;
+        // Returns events on the specified calendar.
+        list(calendarId: string): Calendar.Schema.Events;
+        // Returns events on the specified calendar.
+        list(calendarId: string, optionalArgs: object): Calendar.Schema.Events;
+        // Returns events on the specified calendar.
+        list(calendarId: string, optionalArgs: object, headers: object): Calendar.Schema.Events;
+        // Moves an event to another calendar, i.e. changes an event's organizer.
+        move(calendarId: string, eventId: string, destination: string): Calendar.Schema.Event;
+        // Moves an event to another calendar, i.e. changes an event's organizer.
+        move(
+          calendarId: string,
+          eventId: string,
+          destination: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Event;
+        // Moves an event to another calendar, i.e. changes an event's organizer.
+        move(
+          calendarId: string,
+          eventId: string,
+          destination: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Updates an event. This method supports patch semantics.
+        patch(resource: Schema.Event, calendarId: string, eventId: string): Calendar.Schema.Event;
+        // Updates an event. This method supports patch semantics.
+        patch(
+          resource: Schema.Event,
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Event;
+        // Updates an event. This method supports patch semantics.
+        patch(
+          resource: Schema.Event,
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Creates an event based on a simple text string.
+        quickAdd(calendarId: string, text: string): Calendar.Schema.Event;
+        // Creates an event based on a simple text string.
+        quickAdd(calendarId: string, text: string, optionalArgs: object): Calendar.Schema.Event;
+        // Creates an event based on a simple text string.
+        quickAdd(
+          calendarId: string,
+          text: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Deletes an event.
+        remove(calendarId: string, eventId: string): void;
+        // Deletes an event.
+        remove(calendarId: string, eventId: string, optionalArgs: object): void;
+        // Deletes an event.
+        remove(calendarId: string, eventId: string, optionalArgs: object, headers: object): void;
+        // Updates an event.
+        update(resource: Schema.Event, calendarId: string, eventId: string): Calendar.Schema.Event;
+        // Updates an event.
+        update(
+          resource: Schema.Event,
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Event;
+        // Updates an event.
+        update(
+          resource: Schema.Event,
+          calendarId: string,
+          eventId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Event;
+        // Watch for changes to Events resources.
+        watch(resource: Schema.Channel, calendarId: string): Calendar.Schema.Channel;
+        // Watch for changes to Events resources.
+        watch(
+          resource: Schema.Channel,
+          calendarId: string,
+          optionalArgs: object,
+        ): Calendar.Schema.Channel;
+        // Watch for changes to Events resources.
+        watch(
+          resource: Schema.Channel,
+          calendarId: string,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Channel;
+      }
+      interface FreebusyCollection {
+        // Returns free/busy information for a set of calendars.
+        query(resource: Schema.FreeBusyRequest): Calendar.Schema.FreeBusyResponse;
+        // Returns free/busy information for a set of calendars.
+        query(
+          resource: Schema.FreeBusyRequest,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.FreeBusyResponse;
+      }
+      interface SettingsCollection {
+        // Returns a single user setting.
+        get(setting: string): Calendar.Schema.Setting;
+        // Returns a single user setting.
+        get(setting: string, optionalArgs: object, headers: object): Calendar.Schema.Setting;
+        // Returns all user settings for the authenticated user.
+        list(): Calendar.Schema.Settings;
+        // Returns all user settings for the authenticated user.
+        list(optionalArgs: object): Calendar.Schema.Settings;
+        // Returns all user settings for the authenticated user.
+        list(optionalArgs: object, headers: object): Calendar.Schema.Settings;
+        // Watch for changes to Settings resources.
+        watch(resource: Schema.Channel): Calendar.Schema.Channel;
+        // Watch for changes to Settings resources.
+        watch(resource: Schema.Channel, optionalArgs: object): Calendar.Schema.Channel;
+        // Watch for changes to Settings resources.
+        watch(
+          resource: Schema.Channel,
+          optionalArgs: object,
+          headers: object,
+        ): Calendar.Schema.Channel;
+      }
+    }
+    namespace Schema {
+      interface Acl {
+        etag?: string | undefined;
+        items?: Calendar.Schema.AclRule[] | undefined;
+        kind?: string | undefined;
+        nextPageToken?: string | undefined;
+        nextSyncToken?: string | undefined;
+      }
+      interface AclRule {
+        etag?: string | undefined;
+        id?: string | undefined;
+        kind?: string | undefined;
+        role?: string | undefined;
+        scope?: Calendar.Schema.AclRuleScope | undefined;
+      }
+      interface AclRuleScope {
+        type?: string | undefined;
+        value?: string | undefined;
+      }
+      interface Calendar {
+        conferenceProperties?: Calendar.Schema.ConferenceProperties | undefined;
+        description?: string | undefined;
+        etag?: string | undefined;
+        id?: string | undefined;
+        kind?: string | undefined;
+        location?: string | undefined;
+        summary?: string | undefined;
+        timeZone?: string | undefined;
+      }
+      interface CalendarList {
+        etag?: string | undefined;
+        items?: Calendar.Schema.CalendarListEntry[] | undefined;
+        kind?: string | undefined;
+        nextPageToken?: string | undefined;
+        nextSyncToken?: string | undefined;
+      }
+      interface CalendarListEntry {
+        accessRole?: string | undefined;
+        backgroundColor?: string | undefined;
+        colorId?: string | undefined;
+        conferenceProperties?: Calendar.Schema.ConferenceProperties | undefined;
+        defaultReminders?: Calendar.Schema.EventReminder[] | undefined;
+        deleted?: boolean | undefined;
+        description?: string | undefined;
+        etag?: string | undefined;
+        foregroundColor?: string | undefined;
+        hidden?: boolean | undefined;
+        id?: string | undefined;
+        kind?: string | undefined;
+        location?: string | undefined;
+        notificationSettings?: Calendar.Schema.CalendarListEntryNotificationSettings | undefined;
+        primary?: boolean | undefined;
+        selected?: boolean | undefined;
+        summary?: string | undefined;
+        summaryOverride?: string | undefined;
+        timeZone?: string | undefined;
+      }
+      interface CalendarListEntryNotificationSettings {
+        notifications?: Calendar.Schema.CalendarNotification[] | undefined;
+      }
+      interface CalendarNotification {
+        method?: string | undefined;
+        type?: string | undefined;
+      }
+      interface Channel {
+        address?: string | undefined;
+        expiration?: string | undefined;
+        id?: string | undefined;
+        kind?: string | undefined;
+        params?: object | undefined;
+        payload?: boolean | undefined;
+        resourceId?: string | undefined;
+        resourceUri?: string | undefined;
+        token?: string | undefined;
+        type?: string | undefined;
+      }
+      interface ColorDefinition {
+        background?: string | undefined;
+        foreground?: string | undefined;
+      }
+      interface Colors {
+        calendar?: object | undefined;
+        event?: object | undefined;
+        kind?: string | undefined;
+        updated?: string | undefined;
+      }
+      interface ConferenceData {
+        conferenceId?: string | undefined;
+        conferenceSolution?: Calendar.Schema.ConferenceSolution | undefined;
+        createRequest?: Calendar.Schema.CreateConferenceRequest | undefined;
+        entryPoints?: Calendar.Schema.EntryPoint[] | undefined;
+        notes?: string | undefined;
+        parameters?: Calendar.Schema.ConferenceParameters | undefined;
+        signature?: string | undefined;
+      }
+      interface ConferenceParameters {
+        addOnParameters?: Calendar.Schema.ConferenceParametersAddOnParameters | undefined;
+      }
+      interface ConferenceParametersAddOnParameters {
+        parameters?: Record<string, string> | undefined;
+      }
+      interface ConferenceProperties {
+        allowedConferenceSolutionTypes?: string[] | undefined;
+      }
+      interface ConferenceRequestStatus {
+        statusCode?: string | undefined;
+      }
+      interface ConferenceSolution {
+        iconUri?: string | undefined;
+        key?: Calendar.Schema.ConferenceSolutionKey | undefined;
+        name?: string | undefined;
+      }
+      interface ConferenceSolutionKey {
+        type?: string | undefined;
+      }
+      interface CreateConferenceRequest {
+        conferenceSolutionKey?: Calendar.Schema.ConferenceSolutionKey | undefined;
+        requestId?: string | undefined;
+        status?: Calendar.Schema.ConferenceRequestStatus | undefined;
+      }
+      interface EntryPoint {
+        accessCode?: string | undefined;
+        entryPointFeatures?: string[] | undefined;
+        entryPointType?: string | undefined;
+        label?: string | undefined;
+        meetingCode?: string | undefined;
+        passcode?: string | undefined;
+        password?: string | undefined;
+        pin?: string | undefined;
+        regionCode?: string | undefined;
+        uri?: string | undefined;
+      }
+      interface Error {
+        domain?: string | undefined;
+        reason?: string | undefined;
+      }
+      interface Event {
+        anyoneCanAddSelf?: boolean | undefined;
+        attachments?: Calendar.Schema.EventAttachment[] | undefined;
+        attendees?: Calendar.Schema.EventAttendee[] | undefined;
+        attendeesOmitted?: boolean | undefined;
+        colorId?: string | undefined;
+        conferenceData?: Calendar.Schema.ConferenceData | undefined;
+        created?: string | undefined;
+        creator?: Calendar.Schema.EventCreator | undefined;
+        description?: string | undefined;
+        end?: Calendar.Schema.EventDateTime | undefined;
+        endTimeUnspecified?: boolean | undefined;
+        etag?: string | undefined;
+        eventType?: 'default' | 'outOfOffice' | 'focusTime' | 'workingLocation';
+        extendedProperties?: Calendar.Schema.EventExtendedProperties | undefined;
+        gadget?: Calendar.Schema.EventGadget | undefined;
+        guestsCanInviteOthers?: boolean | undefined;
+        guestsCanModify?: boolean | undefined;
+        guestsCanSeeOtherGuests?: boolean | undefined;
+        hangoutLink?: string | undefined;
+        htmlLink?: string | undefined;
+        iCalUID?: string | undefined;
+        id?: string | undefined;
+        kind?: string | undefined;
+        location?: string | undefined;
+        locked?: boolean | undefined;
+        organizer?: Calendar.Schema.EventOrganizer | undefined;
+        originalStartTime?: Calendar.Schema.EventDateTime | undefined;
+        privateCopy?: boolean | undefined;
+        recurrence?: string[] | undefined;
+        recurringEventId?: string | undefined;
+        reminders?: Calendar.Schema.EventReminders | undefined;
+        sequence?: number | undefined;
+        source?: Calendar.Schema.EventSource | undefined;
+        start?: Calendar.Schema.EventDateTime | undefined;
+        status?: string | undefined;
+        summary?: string | undefined;
+        transparency?: string | undefined;
+        updated?: string | undefined;
+        visibility?: string | undefined;
+        workingLocationProperties?: Calendar.Schema.EventWorkingLocationProperties | undefined;
+      }
+      interface EventAttachment {
+        fileId?: string | undefined;
+        fileUrl?: string | undefined;
+        iconLink?: string | undefined;
+        mimeType?: string | undefined;
+        title?: string | undefined;
+      }
+      interface EventAttendee {
+        additionalGuests?: number | undefined;
+        comment?: string | undefined;
+        displayName?: string | undefined;
+        email?: string | undefined;
+        id?: string | undefined;
+        optional?: boolean | undefined;
+        organizer?: boolean | undefined;
+        resource?: boolean | undefined;
+        responseStatus?: string | undefined;
+        self?: boolean | undefined;
+      }
+      interface EventCreator {
+        displayName?: string | undefined;
+        email?: string | undefined;
+        id?: string | undefined;
+        self?: boolean | undefined;
+      }
+      interface EventDateTime {
+        date?: string | undefined;
+        dateTime?: string | undefined;
+        timeZone?: string | undefined;
+      }
+      interface EventExtendedProperties {
+        private?: Record<string, string> | undefined;
+        shared?: Record<string, string> | undefined;
+      }
+      interface EventGadget {
+        display?: string | undefined;
+        height?: number | undefined;
+        iconLink?: string | undefined;
+        link?: string | undefined;
+        preferences?: object | undefined;
+        title?: string | undefined;
+        type?: string | undefined;
+        width?: number | undefined;
+      }
+      interface EventOrganizer {
+        displayName?: string | undefined;
+        email?: string | undefined;
+        id?: string | undefined;
+        self?: boolean | undefined;
+      }
+      interface EventReminder {
+        method?: string | undefined;
+        minutes?: number | undefined;
+      }
+      interface EventReminders {
+        overrides?: Calendar.Schema.EventReminder[] | undefined;
+        useDefault?: boolean | undefined;
+      }
+      interface EventSource {
+        title?: string | undefined;
+        url?: string | undefined;
+      }
+      interface Events {
+        accessRole?: string | undefined;
+        defaultReminders?: Calendar.Schema.EventReminder[] | undefined;
+        description?: string | undefined;
+        etag?: string | undefined;
+        items?: Calendar.Schema.Event[] | undefined;
+        kind?: string | undefined;
+        nextPageToken?: string | undefined;
+        nextSyncToken?: string | undefined;
+        summary?: string | undefined;
+        timeZone?: string | undefined;
+        updated?: string | undefined;
+      }
+      interface FreeBusyCalendar {
+        busy?: Calendar.Schema.TimePeriod[] | undefined;
+        errors?: Calendar.Schema.Error[] | undefined;
+      }
+      interface FreeBusyGroup {
+        calendars?: string[] | undefined;
+        errors?: Calendar.Schema.Error[] | undefined;
+      }
+      interface FreeBusyRequest {
+        calendarExpansionMax?: number | undefined;
+        groupExpansionMax?: number | undefined;
+        items?: Calendar.Schema.FreeBusyRequestItem[] | undefined;
+        timeMax?: string | undefined;
+        timeMin?: string | undefined;
+        timeZone?: string | undefined;
+      }
+      interface FreeBusyRequestItem {
+        id?: string | undefined;
+      }
+      interface FreeBusyResponse {
+        calendars?: object | undefined;
+        groups?: object | undefined;
+        kind?: string | undefined;
+        timeMax?: string | undefined;
+        timeMin?: string | undefined;
+      }
+      interface Setting {
+        etag?: string | undefined;
+        id?: string | undefined;
+        kind?: string | undefined;
+        value?: string | undefined;
+      }
+      interface Settings {
+        etag?: string | undefined;
+        items?: Calendar.Schema.Setting[] | undefined;
+        kind?: string | undefined;
+        nextPageToken?: string | undefined;
+        nextSyncToken?: string | undefined;
+      }
+      interface TimePeriod {
+        end?: string | undefined;
+        start?: string | undefined;
+      }
+      interface EventWorkingLocationPropertiesOfficeLocation {
+        buildingId?: string | undefined;
+        floorId?: string | undefined;
+        floorSectionId?: string | undefined;
+        deskId?: string | undefined;
+        label?: string | undefined;
+      }
+      interface EventWorkingLocationPropertiesCustomLocation {
+        label: string;
+      }
+      interface EventWorkingLocationProperties {
+        type?: string | undefined;
+        homeOffice?: object | undefined;
+        customLocation?: EventWorkingLocationPropertiesCustomLocation | undefined;
+        officeLocation?: EventWorkingLocationPropertiesOfficeLocation | undefined;
+      }
+    }
+  }
+  interface Calendar {
+    Acl?: Calendar.Collection.AclCollection | undefined;
+    CalendarList?: Calendar.Collection.CalendarListCollection | undefined;
+    Calendars?: Calendar.Collection.CalendarsCollection | undefined;
+    Channels?: Calendar.Collection.ChannelsCollection | undefined;
+    Colors?: Calendar.Collection.ColorsCollection | undefined;
+    Events?: Calendar.Collection.EventsCollection | undefined;
+    Freebusy?: Calendar.Collection.FreebusyCollection | undefined;
+    Settings?: Calendar.Collection.SettingsCollection | undefined;
+    // Create a new instance of AclRule
+    newAclRule(): Calendar.Schema.AclRule;
+    // Create a new instance of AclRuleScope
+    newAclRuleScope(): Calendar.Schema.AclRuleScope;
+    // Create a new instance of Calendar
+    newCalendar(): Calendar.Schema.Calendar;
+    // Create a new instance of CalendarListEntry
+    newCalendarListEntry(): Calendar.Schema.CalendarListEntry;
+    // Create a new instance of CalendarListEntryNotificationSettings
+    newCalendarListEntryNotificationSettings(): Calendar.Schema.CalendarListEntryNotificationSettings;
+    // Create a new instance of CalendarNotification
+    newCalendarNotification(): Calendar.Schema.CalendarNotification;
+    // Create a new instance of Channel
+    newChannel(): Calendar.Schema.Channel;
+    // Create a new instance of ConferenceData
+    newConferenceData(): Calendar.Schema.ConferenceData;
+    // Create a new instance of ConferenceParameters
+    newConferenceParameters(): Calendar.Schema.ConferenceParameters;
+    // Create a new instance of ConferenceParametersAddOnParameters
+    newConferenceParametersAddOnParameters(): Calendar.Schema.ConferenceParametersAddOnParameters;
+    // Create a new instance of ConferenceProperties
+    newConferenceProperties(): Calendar.Schema.ConferenceProperties;
+    // Create a new instance of ConferenceRequestStatus
+    newConferenceRequestStatus(): Calendar.Schema.ConferenceRequestStatus;
+    // Create a new instance of ConferenceSolution
+    newConferenceSolution(): Calendar.Schema.ConferenceSolution;
+    // Create a new instance of ConferenceSolutionKey
+    newConferenceSolutionKey(): Calendar.Schema.ConferenceSolutionKey;
+    // Create a new instance of CreateConferenceRequest
+    newCreateConferenceRequest(): Calendar.Schema.CreateConferenceRequest;
+    // Create a new instance of EntryPoint
+    newEntryPoint(): Calendar.Schema.EntryPoint;
+    // Create a new instance of Event
+    newEvent(): Calendar.Schema.Event;
+    // Create a new instance of EventAttachment
+    newEventAttachment(): Calendar.Schema.EventAttachment;
+    // Create a new instance of EventAttendee
+    newEventAttendee(): Calendar.Schema.EventAttendee;
+    // Create a new instance of EventCreator
+    newEventCreator(): Calendar.Schema.EventCreator;
+    // Create a new instance of EventDateTime
+    newEventDateTime(): Calendar.Schema.EventDateTime;
+    // Create a new instance of EventExtendedProperties
+    newEventExtendedProperties(): Calendar.Schema.EventExtendedProperties;
+    // Create a new instance of EventGadget
+    newEventGadget(): Calendar.Schema.EventGadget;
+    // Create a new instance of EventOrganizer
+    newEventOrganizer(): Calendar.Schema.EventOrganizer;
+    // Create a new instance of EventReminder
+    newEventReminder(): Calendar.Schema.EventReminder;
+    // Create a new instance of EventReminders
+    newEventReminders(): Calendar.Schema.EventReminders;
+    // Create a new instance of EventSource
+    newEventSource(): Calendar.Schema.EventSource;
+    // Create a new instance of FreeBusyRequest
+    newFreeBusyRequest(): Calendar.Schema.FreeBusyRequest;
+    // Create a new instance of FreeBusyRequestItem
+    newFreeBusyRequestItem(): Calendar.Schema.FreeBusyRequestItem;
+    // Create a new instance of EventWorkingLocationProperties
+    newEventWorkingLocationProperties(): Calendar.Schema.EventWorkingLocationProperties;
+    // Create a new instance of EventWorkingLocationPropertiesCustomLocation
+    newEventWorkingLocationPropertiesCustomLocation(): Calendar.Schema.EventWorkingLocationPropertiesCustomLocation;
+    // Create a new instance of EventWorkingLocationPropertiesOfficeLocation
+    newEventWorkingLocationPropertiesOfficeLocation(): Calendar.Schema.EventWorkingLocationPropertiesOfficeLocation;
+  }
+}
+
+declare let Calendar: GoogleAppsScript.Calendar;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "typeRoots": ["./src/types"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
+"@babel/runtime@^7.12.5":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.1.tgz#431f9a794d173b53720e69a6464abc6f0e2a5c57"
+  integrity sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -2749,6 +2756,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.13.tgz#80386b7b27b1131c5fbb7368b8c0d983354c7947"
+  integrity sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
@@ -2789,6 +2803,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp.prototype.flags@^1.5.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,25 @@
     "@svgr/hast-util-to-babel-ast" "8.0.0"
     svg-parser "^2.0.4"
 
+"@tanstack/eslint-plugin-query@^5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.20.1.tgz#861afedd7cde6b98c88cf86a5923bb659122e7af"
+  integrity sha512-oIp7Wh90KHOm1FKCvcv87fiD2H96xo/crFrlhbvqBzR2f0tMEGOK/ANKMGNFQprd6BT6lyZhQPlOEkFdezsjIg==
+  dependencies:
+    "@typescript-eslint/utils" "^6.20.0"
+
+"@tanstack/query-core@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.25.0.tgz#e08ed0a9fad34c8005d1a282e57280031ac50cdc"
+  integrity sha512-vlobHP64HTuSE68lWF1mEhwSRC5Q7gaT+a/m9S+ItuN+ruSOxe1rFnR9j0ACWQ314BPhBEVKfBQ6mHL0OWfdbQ==
+
+"@tanstack/react-query@^5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.25.0.tgz#f4dac794cf10dd956aa56dbbdf67049a5ba2669d"
+  integrity sha512-u+n5R7mLO7RmeiIonpaCRVXNRWtZEef/aVZ/XGWRPa7trBIvGtzlfo0Ah7ZtnTYfrKEVwnZ/tzRCBcoiqJ/tFw==
+  dependencies:
+    "@tanstack/query-core" "5.25.0"
+
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -898,6 +917,14 @@
     "@typescript-eslint/types" "6.18.1"
     "@typescript-eslint/visitor-keys" "6.18.1"
 
+"@typescript-eslint/scope-manager@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz#ea8a9bfc8f1504a6ac5d59a6df308d3a0630a2b1"
+  integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+
 "@typescript-eslint/type-utils@6.18.1":
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz#115cf535f8b39db8301677199ce51151e2daee96"
@@ -913,6 +940,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.18.1.tgz#91617d8080bcd99ac355d9157079970d1d49fefc"
   integrity sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==
 
+"@typescript-eslint/types@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.0.tgz#205724c5123a8fef7ecd195075fa6e85bac3436d"
+  integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
+
 "@typescript-eslint/typescript-estree@6.18.1":
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz#a12b6440175b4cbc9d09ab3c4966c6b245215ab4"
@@ -920,6 +952,20 @@
   dependencies:
     "@typescript-eslint/types" "6.18.1"
     "@typescript-eslint/visitor-keys" "6.18.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/typescript-estree@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz#c47ae7901db3b8bddc3ecd73daff2d0895688c46"
+  integrity sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -940,12 +986,33 @@
     "@typescript-eslint/typescript-estree" "6.18.1"
     semver "^7.5.4"
 
+"@typescript-eslint/utils@^6.20.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.21.0.tgz#4714e7a6b39e773c1c8e97ec587f520840cd8134"
+  integrity sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    semver "^7.5.4"
+
 "@typescript-eslint/visitor-keys@6.18.1":
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz#704d789bda2565a15475e7d22f145b8fe77443f4"
   integrity sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==
   dependencies:
     "@typescript-eslint/types" "6.18.1"
+    eslint-visitor-keys "^3.4.1"
+
+"@typescript-eslint/visitor-keys@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz#87a99d077aa507e20e238b11d56cc26ade45fe47"
+  integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
     eslint-visitor-keys "^3.4.1"
 
 "@ungap/structured-clone@^1.2.0":


### PR DESCRIPTION
## Description

유저의 calendar를 선택할 수 있는 `CalendarSelector` 컴포넌트에 TanStack Query를 적용하여 받아온 CalendarList API 결과를 렌더링한다.

## Issues

Closed #20 
