### PR TITLE
[Refactor/#26] QueryErrorResetBoundary 설정과 에러 정보 제공

### DIFF
--- a/src/components/calendar/CalendarSelector.tsx
+++ b/src/components/calendar/CalendarSelector.tsx
@@ -1,3 +1,4 @@
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '@/components/fallback/ErrorFallback';
@@ -13,12 +14,16 @@ const CalendarDropDown = () => {
 
 const CalendarSelector = () => {
   return (
-    <div>
-      <ErrorBoundary fallback={<ErrorFallback />}>
-        <Suspense fallback={<LoadingFallback />}>
-          <CalendarDropDown />
-        </Suspense>
-      </ErrorBoundary>
+    <div className="py-4">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} FallbackComponent={ErrorFallback}>
+            <Suspense fallback={<LoadingFallback />}>
+              <CalendarDropDown />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </div>
   );
 };

--- a/src/components/fallback/ErrorFallback.tsx
+++ b/src/components/fallback/ErrorFallback.tsx
@@ -1,5 +1,40 @@
-const ErrorFallback = () => {
-  return <div>에러가 발생하였습니다.</div>;
+import { FallbackProps } from 'react-error-boundary';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/button/Button';
+import ERRORS from '@/constants/errors';
+import useSupabaseAuth from '@/hooks/useSupabaseAuth';
+
+const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const navigate = useNavigate();
+  const { logOutWithGoogle } = useSupabaseAuth();
+
+  const statusCode = error.response.status || 0;
+  const errorMessage = ERRORS[statusCode].message;
+  const redirectState = ERRORS[statusCode].redirectState;
+
+  const handleLogoutAndRedirect = (path: string) => {
+    logOutWithGoogle();
+    navigate(`/${path}`);
+  };
+
+  return (
+    <>
+      <p>{errorMessage}</p>
+      {redirectState.redirect ? (
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => handleLogoutAndRedirect(redirectState.path)}
+        >
+          페이지 이동
+        </Button>
+      ) : (
+        <Button variant="contained" color="error" onClick={resetErrorBoundary}>
+          재시도
+        </Button>
+      )}
+    </>
+  );
 };
 
 export default ErrorFallback;

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,88 @@
+import RoutePath from './path';
+
+const ERRORS: ErrorMap = {
+  400: {
+    message: '잘못된 요청입니다.💦',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  401: {
+    message: '잘못된 인증 정보입니다. 재로그인 해주세요.💦',
+    redirectState: {
+      redirect: true,
+      path: RoutePath.LOGIN,
+    },
+  },
+  403: {
+    message: '접근이 금지되었습니다. 재로그인 후에도 같은 문제 발생 시, 개발자에게 문의해주세요.🐛',
+    redirectState: {
+      redirect: true,
+      path: RoutePath.LOGIN,
+    },
+  },
+  404: {
+    message: '요청한 리소스나 페이지를 찾을 수 없습니다.💦',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  409: {
+    message: '충돌이 발생했습니다. 새로운 ID를 생성하거나 업데이트해야합니다.💦',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  410: {
+    message: '요청한 리소스가 더 이상 존재하지 않습니다.💦',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  412: {
+    message:
+      '사전 조건 실패로 요청이 거부되었습니다. 계속해서 같은 문제 발생 시, 개발자에게 문의해주세요.🐛',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  429: {
+    message: '요청이 너무 많습니다. 계속해서 같은 문제 발생 시, 개발자에게 문의해주세요.🐛',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  500: {
+    message: '서버에 오류가 발생했습니다. 계속해서 같은 문제 발생 시, 개발자에게 문의해주세요.🐛',
+    redirectState: {
+      redirect: false,
+    },
+  },
+  0: {
+    message:
+      '예상치 못한 오류가 발생했습니다. 계속해서 같은 문제 발생 시, 개발자에게 문의해주세요.🐛',
+    redirectState: {
+      redirect: false,
+    },
+  },
+} as const;
+
+type RedirectType = {
+  redirect: true;
+  path: string;
+};
+
+type NoRedirectType = {
+  redirect: false;
+};
+
+interface ErrorMap {
+  [code: number]: ErrorResult;
+}
+
+export interface ErrorResult {
+  message: string;
+  redirectState: RedirectType | NoRedirectType;
+}
+
+export default ERRORS;


### PR DESCRIPTION
## Description

1. 명확한 에러 원인을 유저에게 제공하기 위해 개선한다.
2. `QueryErrorResetBoundary`로 쿼리 재요청이 가능하도록 개선한다.

## Issues

Closed #26 
